### PR TITLE
use pageinfo.title in title tag

### DIFF
--- a/views/static/header.ejs
+++ b/views/static/header.ejs
@@ -14,7 +14,7 @@
     }
     %>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" />
-    <title><%= site.title || 'Wago.io'%></title>
+    <title><%= (site.title || 'Wago.io') + (pageinfo && pageinfo.title ? (" | " + pageinfo.title) : "") %></title>
                                                                                                                    
     <link rel="stylesheet" href="/assets/wago.css?v=<%= cache.css %>">
 


### PR DESCRIPTION
haven't managed to get the codebase to run yet so this is untested.

set the `<title>` so that bookmarks will not all be called "WAGO".