### PR TITLE
Adjustments for Plater string indexed mod/script exports

### DIFF
--- a/backend/api/helpers/diff.js
+++ b/backend/api/helpers/diff.js
@@ -16,11 +16,8 @@ module.exports = {
     }
     var tblA = {}
     var tblB = {}
-    if (!Array.isArray(jsonA) || !Array.isArray(jsonB)) {
-      //default -> emtpy array compare
-      //return await makeDiffs({}, {})
-    }
-    else if ((typeof jsonA[8] === 'number' || jsonA.type === 'script') && (typeof jsonB[8] === 'number' || jsonA.type === 'script')) { // Plater script
+    
+    if ((typeof jsonA[8] === 'number' || jsonA.type === 'script') && (typeof jsonB[8] === 'number' || jsonA.type === 'script')) { // Plater script
       if (typeof jsonA[8] === 'number') {
         tblA.Constructor = jsonA[11]
         tblA['On Show'] = jsonA[13]
@@ -51,18 +48,9 @@ module.exports = {
       }
     }
     else if ((typeof jsonA[8] === 'object' || jsonA.type === 'hook') && (typeof jsonB[8] === 'object' || jsonA.type === 'hook')) { // Plater hook
-      if (typeof jsonA[8] === 'object') {
-        tblA = jsonA[8]
-      }
-      else {
-        tblA = jsonA['9']
-      }
-      if (typeof jsonB[8] === 'object') {
-        tblB = jsonB[8]
-      }
-      else {
-        tblB = jsonB['9']
-      }
+      tblA = jsonA['9'] || jsonA[8]
+      tblB = jsonB['9'] || jsonB[8]
+      console.log('sadfsd')
     }
     return await makeDiffs(tblA, tblB)
   },

--- a/backend/api/helpers/diff.js
+++ b/backend/api/helpers/diff.js
@@ -14,25 +14,57 @@ module.exports = {
     catch (e) {
       return await makeDiffs({}, {})
     }
+    var tblA = {}
+    var tblB = {}
     if (!Array.isArray(jsonA) || !Array.isArray(jsonB)) {
-      return await makeDiffs({}, {})
+      //default -> emtpy array compare
+      //return await makeDiffs({}, {})
     }
-    else if (typeof jsonA[8] === 'number' && typeof jsonB[8] === 'number') { // Plater script
-      var tblA = {}
-      var tblB = {}
-      tblA.Constructor = jsonA[11]
-      tblA['On Show'] = jsonA[13]
-      tblA['On Update'] = jsonA[10]
-      tblA['On Hide'] = jsonA[12]
-      tblB.Constructor = jsonB[11]
-      tblB['On Show'] = jsonB[13]
-      tblB['On Update'] = jsonB[10]
-      tblB['On Hide'] = jsonB[12]
-      return await makeDiffs(tblA, tblB)
+    else if ((typeof jsonA[8] === 'number' || jsonA.type === 'script') && (typeof jsonB[8] === 'number' || jsonA.type === 'script')) { // Plater script
+      if (typeof jsonA[8] === 'number') {
+        tblA.Constructor = jsonA[11]
+        tblA['On Show'] = jsonA[13]
+        tblA['On Update'] = jsonA[10]
+        tblA['On Hide'] = jsonA[12]
+	    tblA.Initialization = jsonA[14]
+      }
+      else {
+        tblA.Constructor = jsonA['12']
+        tblA['On Show'] = jsonA['14']
+        tblA['On Update'] = jsonA['11']
+        tblA['On Hide'] = jsonA['13']
+	    tblA.Initialization = jsonA['15']
+      }
+      if (typeof jsonA[8] === 'number') {
+        tblB.Constructor = jsonB[11]
+        tblB['On Show'] = jsonB[13]
+        tblB['On Update'] = jsonB[10]
+        tblB['On Hide'] = jsonB[12]
+	    tblB.Initialization = jsonA[14]
+      }
+      else {
+        tblB.Constructor = jsonB['12']
+        tblB['On Show'] = jsonB['14']
+        tblB['On Update'] = jsonB['11']
+        tblB['On Hide'] = jsonB['13']
+	    tblB.Initialization = jsonA['15']
+      }
     }
-    else if (typeof jsonA[8] === 'object' && typeof jsonB[8] === 'object') { // Plater hook
-      return await makeDiffs(jsonA[8], jsonB[8])
+    else if ((typeof jsonA[8] === 'object' || jsonA.type === 'hook') && (typeof jsonB[8] === 'object' || jsonA.type === 'hook')) { // Plater hook
+      if (typeof jsonA[8] === 'object') {
+        tblA = jsonA[8]
+      }
+      else {
+        tblA = jsonA['9']
+      }
+      if (typeof jsonB[8] === 'object') {
+        tblB = jsonB[8]
+      }
+      else {
+        tblB = jsonB['9']
+      }
     }
+    return await makeDiffs(tblA, tblB)
   },
 
   WeakAuras: async (jsonA, jsonB) => {

--- a/backend/api/helpers/diff.js
+++ b/backend/api/helpers/diff.js
@@ -26,28 +26,28 @@ module.exports = {
         tblA['On Show'] = jsonA[13]
         tblA['On Update'] = jsonA[10]
         tblA['On Hide'] = jsonA[12]
-	    tblA.Initialization = jsonA[14]
+        tblA.Initialization = jsonA[14]
       }
       else {
         tblA.Constructor = jsonA['12']
         tblA['On Show'] = jsonA['14']
         tblA['On Update'] = jsonA['11']
         tblA['On Hide'] = jsonA['13']
-	    tblA.Initialization = jsonA['15']
+        tblA.Initialization = jsonA['15']
       }
       if (typeof jsonA[8] === 'number') {
         tblB.Constructor = jsonB[11]
         tblB['On Show'] = jsonB[13]
         tblB['On Update'] = jsonB[10]
         tblB['On Hide'] = jsonB[12]
-	    tblB.Initialization = jsonA[14]
+        tblB.Initialization = jsonA[14]
       }
       else {
         tblB.Constructor = jsonB['12']
         tblB['On Show'] = jsonB['14']
         tblB['On Update'] = jsonB['11']
         tblB['On Hide'] = jsonB['13']
-	    tblB.Initialization = jsonA['15']
+        tblB.Initialization = jsonA['15']
       }
     }
     else if ((typeof jsonA[8] === 'object' || jsonA.type === 'hook') && (typeof jsonB[8] === 'object' || jsonA.type === 'hook')) { // Plater hook

--- a/backend/api/helpers/lua.js
+++ b/backend/api/helpers/lua.js
@@ -197,12 +197,6 @@ module.exports = {
       return false
     }
 
-    // convert string "1" to int 1 so that lua handles the array properly
-    if (obj['1']) {
-      var tmp = obj['1']
-      delete obj['1']
-      obj[1] = tmp
-    }
     var str = JSON.stringify(obj)
     var result = await runLua('dofile("./wago.lua"); JSON2Plater("' + str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').trim() + '")')
     if (!result || !result.match(commonRegex.looksLikePlater)) {

--- a/backend/api/helpers/luacheck.js
+++ b/backend/api/helpers/luacheck.js
@@ -12,10 +12,7 @@ module.exports = {
     catch (e) {
       return []
     }
-    if (!Array.isArray(json)) {
-      return []
-    }
-    else if (json.type === 'script') { // Plater script
+    if (json.type === 'script') { // Plater script
       var tbl = {}
       tbl.Constructor = json['12']
       tbl['On Show'] = json['14']

--- a/backend/api/helpers/luacheck.js
+++ b/backend/api/helpers/luacheck.js
@@ -21,7 +21,7 @@ module.exports = {
       tbl['On Show'] = json['14']
       tbl['On Update'] = json['11']
       tbl['On Hide'] = json['13']
-	  tbl.Initialization = json['15']
+      tbl.Initialization = json['15']
       return await makeLuaCheck(tbl)
     }
     else if (json.type === 'hook') { // Plater hook
@@ -33,7 +33,7 @@ module.exports = {
       tbl['On Show'] = json[13]
       tbl['On Update'] = json[10]
       tbl['On Hide'] = json[12]
-	  tbl.Initialization = json[14]
+      tbl.Initialization = json[14]
       return await makeLuaCheck(tbl)
     }
     else if (typeof json[8] === 'object') { // Plater hook - fallback

--- a/backend/api/helpers/luacheck.js
+++ b/backend/api/helpers/luacheck.js
@@ -15,15 +15,28 @@ module.exports = {
     if (!Array.isArray(json)) {
       return []
     }
-    else if (typeof json[8] === 'number') { // Plater script
+    else if (json.type === 'script') { // Plater script
+      var tbl = {}
+      tbl.Constructor = json['12']
+      tbl['On Show'] = json['14']
+      tbl['On Update'] = json['11']
+      tbl['On Hide'] = json['13']
+	  tbl.Initialization = json['15']
+      return await makeLuaCheck(tbl)
+    }
+    else if (json.type === 'hook') { // Plater hook
+      return await makeLuaCheck(json['9'])
+    }
+    else if (typeof json[8] === 'number') { // Plater script - fallback
       var tbl = {}
       tbl.Constructor = json[11]
       tbl['On Show'] = json[13]
       tbl['On Update'] = json[10]
       tbl['On Hide'] = json[12]
+	  tbl.Initialization = json[14]
       return await makeLuaCheck(tbl)
     }
-    else if (typeof json[8] === 'object') { // Plater hook
+    else if (typeof json[8] === 'object') { // Plater hook - fallback
       return await makeLuaCheck(json[8])
     }
   },

--- a/backend/api/lua/wago.lua
+++ b/backend/api/lua/wago.lua
@@ -453,15 +453,11 @@ end
 
 function JSON2Plater(json)
   local t = JSON:decode(json)
-  if t and t["1"] then
-    n = 1
-    while t[""..n] do
-      tinsert(t, t[""..n])
-      t[""..n] = nil
-      n = n+1
-    end
+  if (t) then
+    print(TableToDeflate(t))
+  else
+    print("")
   end
-  print(TableToDeflate(t))
 end
 
 

--- a/backend/api/services/import.js
+++ b/backend/api/services/import.js
@@ -301,7 +301,7 @@ module.exports = function (fastify, opts, next) {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
         return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[0], categories: []})
-      }	  
+      }	 
       // if Plater Hook is found - old data type
       else if ((typeof decoded.obj[8] === 'object' || typeof decoded.obj['9'] === 'object') && (typeof decoded.obj[0] === 'string' || typeof decoded.obj['1'] === 'string')) {
         scan.type = 'PLATER'

--- a/backend/api/services/import.js
+++ b/backend/api/services/import.js
@@ -283,7 +283,7 @@ module.exports = function (fastify, opts, next) {
         return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: 'Plater NPC Colors', categories: []})
       }
       // animation
-      else if ((decoded.obj[1] && decoded.obj[1].animation_type) || decoded.obj['2'] && decoded.obj['2'].animation_type) {
+      else if ((decoded.obj[1] && decoded.obj[1].animation_type) || (decoded.obj['2'] && decoded.obj['2'].animation_type)) {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
         var name = 'Plater Animation'
@@ -296,13 +296,25 @@ module.exports = function (fastify, opts, next) {
         }
         return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: 'Plater Animation', categories: []})
       }
-      // if Plater Hook is found
+      // if Plater Hook is found - new data type
+      else if (decoded.obj.type === 'hook') {
+        scan.type = 'PLATER'
+        const scanDoc = await scan.save()
+        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[0], categories: []})
+      }	  
+      // if Plater Hook is found - old data type
       else if ((typeof decoded.obj[8] === 'object' || typeof decoded.obj['9'] === 'object') && (typeof decoded.obj[0] === 'string' || typeof decoded.obj['1'] === 'string')) {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
         return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[0], categories: []})
       }
-      // if Plater Script is found
+      // if Plater Script is found - new data type
+      else if ((decoded.obj.type === 'script') {
+        scan.type = 'PLATER'
+        const scanDoc = await scan.save()
+        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[1], categories: []})
+      }
+      // if Plater Script is found - old data type
       else if ((typeof decoded.obj[8] === 'number' || typeof decoded.obj['9'] === 'number') && (typeof decoded.obj[1] === 'string' || typeof decoded.obj['2'] === 'string')) {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
@@ -386,8 +398,14 @@ module.exports = function (fastify, opts, next) {
     else if (wago.type === 'TOTALRP3' && json[2] && json[2].NT) {
       wago.description = json[2].NT
     }
+    else if (wago.type === 'PLATER' && json.type === 'script') {
+      wago.description = json['6']
+    }
     else if (wago.type === 'PLATER' && Array.isArray(json) && typeof json[8] === 'number') {
       wago.description = json[5]
+    }
+    else if (wago.type === 'PLATER' && json.type === 'hook') {
+      wago.description = json['3']
     }
     else if (wago.type === 'PLATER' && Array.isArray(json) && typeof json[8] === 'object') {
       wago.description = json[2]
@@ -402,6 +420,17 @@ module.exports = function (fastify, opts, next) {
         wago.game = 'classic'
       }
       else if ((json.d.tocversion+'').match(/^90/)) {
+        wago.game = 'sl' // shadowlands
+      }
+      else {
+        wago.game = 'bfa' // battle for azeroth
+      }
+    }
+    else if (wago.type.match(/PLATER/) && json.tocversion) {
+      if ((json.tocversion+'').match(/^113/)) {
+        wago.game = 'classic'
+      }
+      else if ((json.tocversion+'').match(/^90/)) {
         wago.game = 'sl' // shadowlands
       }
       else {

--- a/backend/api/services/import.js
+++ b/backend/api/services/import.js
@@ -300,7 +300,7 @@ module.exports = function (fastify, opts, next) {
       else if (decoded.obj.type === 'hook') {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
-        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[0], categories: []})
+        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj['1'], categories: []})
       }	 
       // if Plater Hook is found - old data type
       else if ((typeof decoded.obj[8] === 'object' || typeof decoded.obj['9'] === 'object') && (typeof decoded.obj[0] === 'string' || typeof decoded.obj['1'] === 'string')) {
@@ -309,10 +309,10 @@ module.exports = function (fastify, opts, next) {
         return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[0], categories: []})
       }
       // if Plater Script is found - new data type
-      else if ((decoded.obj.type === 'script') {
+      else if (decoded.obj.type === 'script') {
         scan.type = 'PLATER'
         const scanDoc = await scan.save()
-        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj[1], categories: []})
+        return res.send({scan: scanDoc._id.toString(), type: 'PLATER', name: decoded.obj['2'], categories: []})
       }
       // if Plater Script is found - old data type
       else if ((typeof decoded.obj[8] === 'number' || typeof decoded.obj['9'] === 'number') && (typeof decoded.obj[1] === 'string' || typeof decoded.obj['2'] === 'string')) {
@@ -570,17 +570,17 @@ module.exports = function (fastify, opts, next) {
         // plater npc color
         wago.categories.push('plater5')
       }
-      else if (!Array.isArray(json)) {
-        // plater profile
-        wago.categories.push('plater1')
-      }
-      else if (Array.isArray(json) && typeof json[8] === 'number') {
+      else if ((Array.isArray(json) && typeof json[8] === 'number') || json.type === 'script') {
         // plater script
         wago.categories.push('plater2')
       }
-      else if (Array.isArray(json) && typeof json[8] === 'object') {
+      else if ((Array.isArray(json) && typeof json[8] === 'object') || json.type === 'hook') {
         // plater hook
         wago.categories.push('plater3')
+      }
+      else if (!Array.isArray(json)) {
+        // plater profile
+        wago.categories.push('plater1')
       }
     }
 


### PR DESCRIPTION
Intending to support string-based table indexes from Plater exports. This is prepared on Plater side and can be released soon. I'd like to test this somewhere safe before pushing this publicly and can share some of of the new exports if no test system is available.

- adding 'type' identifiers for 'hook' and 'script'
- adding support for imported tables with static string indexes instead of numbers
- handle the tables with string indexes internally  (Plater supports importing these since a while already)