### PR TITLE
preload the font file to speed up fonts loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link rel="preload" href="https://media.wago.io/fonts.css" crossorigin>
+    <link rel="preload" href="https://media.wago.io/fonts/fonts.css" crossorigin>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0" />
     <meta content="ie=edge" http-equiv=X-UA-Compatible>
     <title>Wago</title>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link rel="preload" href="https://media.wago.io/fonts.css" crossorigin>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0" />
     <meta content="ie=edge" http-equiv=X-UA-Compatible>
     <title>Wago</title>


### PR DESCRIPTION
adding the preload string can reduce the time needed for the fonts file to be retrieved, thus getting the fonts css file faster.

In the end this may only shave off 50ms, but loading those fonts as quickly as possible is important.