### PR TITLE
Resolved issue with double '?' in query string

### DIFF
--- a/backend/api/helpers/webhooks.js
+++ b/backend/api/helpers/webhooks.js
@@ -53,7 +53,15 @@ module.exports = {
                     },
                     fields: [{ name: `Version ${wago.latestVersion.versionString}`, value: wago.latestVersion.changelog.text.replace(/\[(\w+)[^\]]*](.*?)\[\/\1]/g, '$2') }]
                 }]
-                response = await axios.post(`${url}?wait=true`, {embeds: data})
+
+                let appendedUrl
+                if (url.indexOf('?')){
+                    appendedUrl = `${url}&wait=true`
+                } else {
+                    appendedUrl = `${url}?wait=true`
+                }
+                
+                response = await axios.post(appendedUrl, {embeds: data})
             }
             else {
                 data = {


### PR DESCRIPTION
In #258 i forgot to handle situation that would arise with double questionmark in url, with '?wait=true' being appended. 

This would result in a poorly formatted query string like this:
?thread_id=123?wait=true

Resulting in the following response from discord:
![image](https://github.com/user-attachments/assets/591d9603-78da-4b6c-b02d-386164000ef8)
